### PR TITLE
add 2w report retention to model

### DIFF
--- a/backend/model/report.go
+++ b/backend/model/report.go
@@ -13,6 +13,8 @@ func (r ReportRetention) Duration() time.Duration {
 	switch r {
 	case ReportRetentionOneWeek:
 		return 7 * 24 * time.Hour
+	case ReportRetentionTwoWeeks:
+		return 14 * 24 * time.Hour
 	default:
 		panic("invalid report retention")
 	}


### PR DESCRIPTION
## What It Does

This adds a missing case to the `model.ReportRetention` `Duration` method.