### PR TITLE
head s3 bucket instead of using GetBucketLocation

### DIFF
--- a/aws/lib/regional-stack.ts
+++ b/aws/lib/regional-stack.ts
@@ -87,8 +87,8 @@ export class RegionalStack extends Stack {
         const integrationTemplateUpload = new s3deploy.BucketDeployment(this, 'UploadIntegrationTemplate', {
             sources: [
                 s3deploy.Source.data(
-                    'integration-v1.cfn.yaml',
-                    fs.readFileSync(path.join(__dirname, '../../frontend/public/integration-v1.cfn.yaml'), 'utf8'),
+                    'integration-v2.cfn.yaml',
+                    fs.readFileSync(path.join(__dirname, '../../frontend/public/integration-v2.cfn.yaml'), 'utf8'),
                 ),
             ],
             destinationBucket: publicS3Bucket,

--- a/backend/app/apptest/aws.go
+++ b/backend/app/apptest/aws.go
@@ -37,12 +37,7 @@ var bucketPaths = map[string]string{
 	"aws-cloudtrail-logs": "report/testdata/aws-cloudtrail-logs",
 }
 
-type TestAmazonS3API struct {
-}
-
-func (api *TestAmazonS3API) GetBucketLocation(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
-	return &s3.GetBucketLocationOutput{}, nil
-}
+type TestAmazonS3API struct{}
 
 func (api *TestAmazonS3API) HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
 	return &s3.HeadObjectOutput{}, nil
@@ -123,7 +118,11 @@ func (api *TestAmazonS3API) ListObjectsV2(ctx context.Context, params *s3.ListOb
 
 type TestAmazonS3APIFactory struct{}
 
-func (f TestAmazonS3APIFactory) NewFromSTSCredentials(ctx context.Context, credentials *ststypes.Credentials) (app.AmazonS3API, error) {
+func (TestAmazonS3APIFactory) GetBucketRegion(ctx context.Context, bucketName string) (string, error) {
+	return "us-east-1", nil
+}
+
+func (f TestAmazonS3APIFactory) NewFromSTSCredentials(ctx context.Context, credentials *ststypes.Credentials, region string) (app.AmazonS3API, error) {
 	return &TestAmazonS3API{}, nil
 }
 

--- a/backend/app/aws.go
+++ b/backend/app/aws.go
@@ -2,14 +2,15 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"math"
+	"net/http"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
@@ -35,7 +36,6 @@ func (LiveAWSOrganizationsAPIFactory) NewFromSTSCredentials(ctx context.Context,
 }
 
 type AmazonS3API interface {
-	GetBucketLocation(ctx context.Context, params *s3.GetBucketLocationInput, optFns ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
 	HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
 	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
 	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
@@ -43,15 +43,34 @@ type AmazonS3API interface {
 }
 
 type AmazonS3APIFactory interface {
-	NewFromSTSCredentials(ctx context.Context, credentials *ststypes.Credentials) (AmazonS3API, error)
+	GetBucketRegion(ctx context.Context, bucketName string) (string, error)
+	NewFromSTSCredentials(ctx context.Context, credentials *ststypes.Credentials, region string) (AmazonS3API, error)
 }
 
 type LiveAmazonS3APIFactory struct{}
 
-func (LiveAmazonS3APIFactory) NewFromSTSCredentials(ctx context.Context, creds *ststypes.Credentials) (AmazonS3API, error) {
+func (LiveAmazonS3APIFactory) GetBucketRegion(ctx context.Context, bucketName string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://"+bucketName+".s3.amazonaws.com", nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	if region := resp.Header.Get("x-amz-bucket-region"); region != "" {
+		return region, nil
+	}
+	return "", fmt.Errorf("unable to determine bucket region")
+}
+
+func (LiveAmazonS3APIFactory) NewFromSTSCredentials(ctx context.Context, creds *ststypes.Credentials, region string) (AmazonS3API, error) {
 	awsConfig, err := config.LoadDefaultConfig(ctx, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(*creds.AccessKeyId, *creds.SecretAccessKey, *creds.SessionToken)))
 	if err != nil {
 		return nil, err
+	}
+	if region != "" {
+		awsConfig.Region = region
 	}
 	return s3.NewFromConfig(awsConfig), nil
 }
@@ -153,18 +172,6 @@ func MostSimilarKnownAWSRegion(region string) string {
 	}
 
 	return best
-}
-
-// https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html#API_GetBucketLocation_ResponseSyntax
-func S3BucketLocationConstraintRegion(locationConstraint s3types.BucketLocationConstraint) string {
-	switch locationConstraint {
-	case "":
-		return "us-east-1"
-	case "EU":
-		return "eu-west-1"
-	default:
-		return string(locationConstraint)
-	}
 }
 
 func (a *App) ClosestAvailableAWSRegion(region string) string {

--- a/backend/app/aws.go
+++ b/backend/app/aws.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"io"
 	"math"
 	"net/http"
 
@@ -56,6 +57,10 @@ func (LiveAmazonS3APIFactory) GetBucketRegion(ctx context.Context, bucketName st
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
 		return "", err
 	}
 	if region := resp.Header.Get("x-amz-bucket-region"); region != "" {

--- a/backend/app/report_test.go
+++ b/backend/app/report_test.go
@@ -40,6 +40,7 @@ func TestGenerateAWSCloudTrailReport(t *testing.T) {
 		AccountsKeyPrefix: "AWSLogs/o-1234abcde/",
 		AccountId:         "222222222222",
 		Region:            "us-east-1",
+		BucketRegion:      "us-east-1",
 		Retention:         model.ReportRetentionOneWeek,
 	})
 	require.NoError(t, err)

--- a/frontend/public/integration-v2.cfn.yaml
+++ b/frontend/public/integration-v2.cfn.yaml
@@ -126,9 +126,6 @@ Resources:
                     - Action:
                           - s3:GetObject
                           - s3:ListBucket
-                          # We use the bucket location to optimize ingest. We'll ingest from the
-                          # same region if we can. Otherwise, we'll use the closest one possible.
-                          - s3:GetBucketLocation
                       Effect: Allow
                       Resource:
                           - !Sub 'arn:aws:s3:::${S3BucketName}'

--- a/frontend/src/integration.ts
+++ b/frontend/src/integration.ts
@@ -1,4 +1,4 @@
-const REVISION = 1;
+const REVISION = 2;
 
 export const INTEGRATION_TEMPLATE_URL = `${process.env.NEXT_PUBLIC_CDN_URL || ''}/integration-v${REVISION}.cfn.yaml`;
 export const INTEGRATION_TEMPLATE_S3_URL = `https://s3.amazonaws.com/${process.env.NEXT_PUBLIC_PUBLIC_S3_BUCKET_NAME || ''}/integration-v${REVISION}.cfn.yaml`;


### PR DESCRIPTION
## What It Does

> We recommend that you use [HeadBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html) to return the Region that a bucket resides in.

– https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html

So this PR does that now. This has the added benefit of requiring even fewer permissions in the integration role.