### PR TITLE
improve handling for ids in arn format

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/rs/cors"
 	"go.uber.org/zap"
 
@@ -129,6 +130,7 @@ func New(a *app.App, config Config) *API {
 			}
 		},
 	}), apispec.GorillaServerOptions{
+		BaseRouter: mux.NewRouter().UseEncodedPath(),
 		Middlewares: []apispec.MiddlewareFunc{
 			AddRequestToContextMiddleware,
 			NoCachingMiddleware,

--- a/frontend/src/app/(user-area)/teams/[teamId]/ContextPanel.tsx
+++ b/frontend/src/app/(user-area)/teams/[teamId]/ContextPanel.tsx
@@ -311,9 +311,11 @@ const PrincipalContext = ({ id, combinedReport }: PrincipalContextProps) => {
                     )}
                 </div>
             </div>
-            <p>
-                <strong>Id:</strong> {id}
-            </p>
+            {id !== principal.arn && (
+                <p className="break-words">
+                    <strong>Id:</strong> {id}
+                </p>
+            )}
             {principal.arn && (
                 <p className="break-words">
                     <strong>ARN:</strong> {principal.arn}


### PR DESCRIPTION
## What It Does

- Allow API to handle principal keys with encoded slashes in them.
- Only display a principal id if it differs from the ARN.