### PR TITLE
move principal key parameter to query

### DIFF
--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gorilla/mux"
 	"github.com/rs/cors"
 	"go.uber.org/zap"
 
@@ -130,7 +129,6 @@ func New(a *app.App, config Config) *API {
 			}
 		},
 	}), apispec.GorillaServerOptions{
-		BaseRouter: mux.NewRouter().UseEncodedPath(),
 		Middlewares: []apispec.MiddlewareFunc{
 			AddRequestToContextMiddleware,
 			NoCachingMiddleware,

--- a/backend/api/apispec/openapi.yaml
+++ b/backend/api/apispec/openapi.yaml
@@ -774,14 +774,23 @@ paths:
                 $ref: '#/components/schemas/TeamMembership'
         '404':
           $ref: '#/components/responses/ErrorResponse'
-  /teams/{teamId}/principal-settings/{principalKey}:
+  /teams/{teamId}/principal-settings:
     parameters:
       - in: path
         name: teamId
         schema:
           type: string
         required: true
-      - in: path
+        # This should probably be a path parameter, but it can contain slashes and API gateway
+        # doesn't seem capable of handling URL-encoded slashes correctly.
+        #
+        # Related links:
+        #
+        # https://www.reddit.com/r/aws/comments/ykpvsn/api_gateway_http_proxy_is_unencoding_my_url/
+        # https://stackoverflow.com/questions/69677023/aws-api-gateway-expects-the-request-url-to-be-encoded-twice
+        # https://repost.aws/questions/QUg-guZiB-RHqoUXtBWjVg0w/issue-with-slashes-for-integrating-api-gateway-with-cloudsearch
+        # https://stackoverflow.com/questions/37199004/how-to-force-api-gateway-to-not-decode-parameters-or-cloudsearch-to-expects-deco
+      - in: query
         name: principalKey
         schema:
           type: string

--- a/backend/api/team.go
+++ b/backend/api/team.go
@@ -275,7 +275,7 @@ func (api *API) GetTeamPrincipalSettings(ctx context.Context, request apispec.Ge
 	sess := ctxSession(ctx)
 	teamId := model.Id(request.TeamId)
 
-	if settings, err := sess.GetTeamPrincipalSettingsByTeamIdAndPrincipalKey(ctx, teamId, request.PrincipalKey); err != nil {
+	if settings, err := sess.GetTeamPrincipalSettingsByTeamIdAndPrincipalKey(ctx, teamId, request.Params.PrincipalKey); err != nil {
 		return nil, err
 	} else if settings == nil {
 		return apispec.GetTeamPrincipalSettings200JSONResponse(apispec.TeamPrincipalSettings{}), nil
@@ -288,7 +288,7 @@ func (api *API) UpdateTeamPrincipalSettings(ctx context.Context, request apispec
 	sess := ctxSession(ctx)
 	teamId := model.Id(request.TeamId)
 
-	if settings, err := sess.CreateOrPatchTeamPrincipalSettingsByTeamIdAndPrincipalKey(ctx, teamId, request.PrincipalKey, app.TeamPrincipalSettingsPatch{
+	if settings, err := sess.CreateOrPatchTeamPrincipalSettingsByTeamIdAndPrincipalKey(ctx, teamId, request.Params.PrincipalKey, app.TeamPrincipalSettingsPatch{
 		Description: request.Body.Description,
 	}); err != nil {
 		return nil, err

--- a/backend/api/team_test.go
+++ b/backend/api/team_test.go
@@ -1,10 +1,6 @@
 package api
 
 import (
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"testing"
 	"time"
 
@@ -311,8 +307,10 @@ func TestAPI_TeamPrincipalSettings(t *testing.T) {
 
 	t.Run("Default", func(t *testing.T) {
 		resp, err := api.GetTeamPrincipalSettings(aliceCtx, apispec.GetTeamPrincipalSettingsRequestObject{
-			TeamId:       team.Id.String(),
-			PrincipalKey: principalKey,
+			TeamId: team.Id.String(),
+			Params: apispec.GetTeamPrincipalSettingsParams{
+				PrincipalKey: principalKey,
+			},
 		})
 		require.NoError(t, err)
 		settings := resp.(apispec.GetTeamPrincipalSettings200JSONResponse)
@@ -320,8 +318,10 @@ func TestAPI_TeamPrincipalSettings(t *testing.T) {
 	})
 
 	resp, err := api.UpdateTeamPrincipalSettings(aliceCtx, apispec.UpdateTeamPrincipalSettingsRequestObject{
-		TeamId:       team.Id.String(),
-		PrincipalKey: principalKey,
+		TeamId: team.Id.String(),
+		Params: apispec.UpdateTeamPrincipalSettingsParams{
+			PrincipalKey: principalKey,
+		},
 		Body: &apispec.UpdateTeamPrincipalSettingsJSONRequestBody{
 			Description: pointer("This is a description."),
 		},
@@ -332,35 +332,22 @@ func TestAPI_TeamPrincipalSettings(t *testing.T) {
 
 	t.Run("Get", func(t *testing.T) {
 		resp, err := api.GetTeamPrincipalSettings(aliceCtx, apispec.GetTeamPrincipalSettingsRequestObject{
-			TeamId:       team.Id.String(),
-			PrincipalKey: principalKey,
+			TeamId: team.Id.String(),
+			Params: apispec.GetTeamPrincipalSettingsParams{
+				PrincipalKey: principalKey,
+			},
 		})
 		require.NoError(t, err)
 		settings := resp.(apispec.GetTeamPrincipalSettings200JSONResponse)
 		assert.Equal(t, "This is a description.", *settings.Description)
 	})
 
-	t.Run("SlashInKey", func(t *testing.T) {
-		const principalKey = "foo/bar"
-
-		w := httptest.NewRecorder()
-		r, err := http.NewRequest("GET", "/teams/"+team.Id.String()+"/principal-settings/"+url.PathEscape(principalKey), nil)
-		require.NoError(t, err)
-		r.Header.Set("Authorization", "token foo")
-		api.ServeHTTP(w, r)
-
-		resp := w.Result()
-		body, err := ioutil.ReadAll(resp.Body)
-		require.NoError(t, err)
-		resp.Body.Close()
-
-		require.Equal(t, http.StatusUnauthorized, resp.StatusCode, "%v", string(body))
-	})
-
 	t.Run("Update", func(t *testing.T) {
 		resp, err := api.UpdateTeamPrincipalSettings(aliceCtx, apispec.UpdateTeamPrincipalSettingsRequestObject{
-			TeamId:       team.Id.String(),
-			PrincipalKey: principalKey,
+			TeamId: team.Id.String(),
+			Params: apispec.UpdateTeamPrincipalSettingsParams{
+				PrincipalKey: principalKey,
+			},
 			Body: &apispec.UpdateTeamPrincipalSettingsJSONRequestBody{
 				Description: pointer("This is a new description."),
 			},
@@ -371,8 +358,10 @@ func TestAPI_TeamPrincipalSettings(t *testing.T) {
 
 		t.Run("Get", func(t *testing.T) {
 			resp, err := api.GetTeamPrincipalSettings(aliceCtx, apispec.GetTeamPrincipalSettingsRequestObject{
-				TeamId:       team.Id.String(),
-				PrincipalKey: principalKey,
+				TeamId: team.Id.String(),
+				Params: apispec.GetTeamPrincipalSettingsParams{
+					PrincipalKey: principalKey,
+				},
 			})
 			require.NoError(t, err)
 			settings := resp.(apispec.GetTeamPrincipalSettings200JSONResponse)


### PR DESCRIPTION
## What It Does

Unfortunately API gateway doesn't seem capable of handling URL-encoded slashes correctly.

Related links:

- https://www.reddit.com/r/aws/comments/ykpvsn/api_gateway_http_proxy_is_unencoding_my_url/
- https://stackoverflow.com/questions/69677023/aws-api-gateway-expects-the-request-url-to-be-encoded-twice
- https://repost.aws/questions/QUg-guZiB-RHqoUXtBWjVg0w/issue-with-slashes-for-integrating-api-gateway-with-cloudsearch
- https://stackoverflow.com/questions/37199004/how-to-force-api-gateway-to-not-decode-parameters-or-cloudsearch-to-expects-deco