### PR TITLE
add scp management apis

### DIFF
--- a/backend/api/apispec/openapi.yaml
+++ b/backend/api/apispec/openapi.yaml
@@ -522,6 +522,86 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/AWSAccount'
+  /teams/{teamId}/aws-accounts/{accountId}/access-report:
+    parameters:
+      - in: path
+        name: teamId
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: accountId
+        schema:
+          type: string
+        required: true
+    get:
+      security:
+        - ApiKeyAuth: []
+      tags:
+        - aws
+      summary: Gets an access report for an account.
+      description: Gets an access report for an account.
+      operationId: getAWSAccessReport
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AWSAccessReport'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+  /teams/{teamId}/aws-accounts/{accountId}/managed-scp:
+    parameters:
+      - in: path
+        name: teamId
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: accountId
+        schema:
+          type: string
+        required: true
+    get:
+      security:
+        - ApiKeyAuth: []
+      tags:
+        - aws
+      summary: Gets a managed SCP for an account.
+      description: Gets a managed SCP for an account, if one exists.
+      operationId: getManagedAWSSCP
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AWSSCP'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+    put:
+      security:
+        - ApiKeyAuth: []
+      tags:
+        - aws
+      summary: Creates or updates a managed SCP.
+      description: Creates or updates a managed SCP.
+      operationId: putManagedAWSSCP
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PutAWSSCPInput'
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AWSSCP'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
   /teams/{teamId}/aws-integrations:
     parameters:
       - in: path
@@ -1184,11 +1264,19 @@ components:
       type: object
       required:
         - id
+        - canManageScps
+        - integrationIds
       properties:
         id:
           type: string
         name:
           type: string
+        canManageScps:
+          type: boolean
+        integrationIds:
+          type: array
+          items:
+            type: string
     AWSIntegration:
       type: object
       required:
@@ -1198,6 +1286,7 @@ components:
         - teamId
         - roleArn
         - getAccountNamesFromOrganizations
+        - manageScps
       properties:
         id:
           type: string
@@ -1211,6 +1300,8 @@ components:
         roleArn:
           type: string
         getAccountNamesFromOrganizations:
+          type: boolean
+        manageScps:
           type: boolean
         cloudtrailTrail:
           $ref: '#/components/schemas/AWSIntegrationCloudTrailTrail'
@@ -1248,6 +1339,42 @@ components:
           type: number
         longitude:
           type: number
+    AWSSCP:
+      type: object
+      required:
+        - content
+      properties:
+        content:
+          type: string
+    PutAWSSCPInput:
+      type: object
+      required:
+        - content
+      properties:
+        content:
+          type: string
+    AWSAccessReport:
+      type: object
+      required:
+        - services
+      properties:
+        services:
+          type: array
+          items:
+            $ref: '#/components/schemas/AWSAccessReportService'
+    AWSAccessReportService:
+      type: object
+      required:
+        - name
+        - namespace
+      properties:
+        name:
+          type: string
+        namespace:
+          type: string
+        lastAuthenticationTime:
+          type: string
+          format: date-time
     CreateAWSIntegrationInput:
       type: object
       required:
@@ -1259,6 +1386,8 @@ components:
         roleArn:
           type: string
         getAccountNamesFromOrganizations:
+          type: boolean
+        manageScps:
           type: boolean
         cloudtrailTrail:
           $ref: '#/components/schemas/CreateAWSIntegrationCloudTrailTrailInput'

--- a/backend/api/aws_integration_test.go
+++ b/backend/api/aws_integration_test.go
@@ -130,3 +130,89 @@ func TestAPI_CreateAWSIntegration_WithBackfill(t *testing.T) {
 		assert.Len(t, accounts, 0)
 	})
 }
+
+func TestAPI_AWSIntegration_SCP_Management(t *testing.T) {
+	api := NewTestAPI(t)
+	_, aliceCtx := api.NewTestUser("alice@example.com", model.UserRoleCustomer)
+
+	team := api.NewTestTeamWithSubscription(aliceCtx, app.TeamSubscriptionTierIndividual)
+
+	{
+		resp, err := api.CreateAWSIntegration(aliceCtx, apispec.CreateAWSIntegrationRequestObject{
+			TeamId: team.Id.String(),
+			Body: &apispec.CreateAWSIntegrationJSONRequestBody{
+				Name:                             "Foo",
+				RoleArn:                          "arn:aws:iam::123456789012:role/MyRole",
+				GetAccountNamesFromOrganizations: pointer(true),
+				ManageScps:                       pointer(true),
+			},
+		})
+		require.NoError(t, err)
+		integration := resp.(apispec.CreateAWSIntegration200JSONResponse)
+		assert.Equal(t, "Foo", integration.Name)
+	}
+
+	t.Run("NoSCP", func(t *testing.T) {
+		_, err := api.GetManagedAWSSCP(aliceCtx, apispec.GetManagedAWSSCPRequestObject{
+			TeamId:    team.Id.String(),
+			AccountId: "123456789012",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("CreateSCP", func(t *testing.T) {
+		resp, err := api.PutManagedAWSSCP(aliceCtx, apispec.PutManagedAWSSCPRequestObject{
+			TeamId:    team.Id.String(),
+			AccountId: "123456789012",
+			Body: &apispec.PutManagedAWSSCPJSONRequestBody{
+				Content: "foo",
+			},
+		})
+		require.NoError(t, err)
+		scp := resp.(apispec.PutManagedAWSSCP200JSONResponse)
+		assert.Equal(t, "foo", scp.Content)
+
+		t.Run("GetSCP", func(t *testing.T) {
+			resp, err := api.GetManagedAWSSCP(aliceCtx, apispec.GetManagedAWSSCPRequestObject{
+				TeamId:    team.Id.String(),
+				AccountId: "123456789012",
+			})
+			require.NoError(t, err)
+			scp := resp.(apispec.GetManagedAWSSCP200JSONResponse)
+			assert.Equal(t, "foo", scp.Content)
+		})
+
+		t.Run("UpdateSCP", func(t *testing.T) {
+			resp, err := api.PutManagedAWSSCP(aliceCtx, apispec.PutManagedAWSSCPRequestObject{
+				TeamId:    team.Id.String(),
+				AccountId: "123456789012",
+				Body: &apispec.PutManagedAWSSCPJSONRequestBody{
+					Content: "bar",
+				},
+			})
+			require.NoError(t, err)
+			scp := resp.(apispec.PutManagedAWSSCP200JSONResponse)
+			assert.Equal(t, "bar", scp.Content)
+
+			t.Run("GetSCP", func(t *testing.T) {
+				resp, err := api.GetManagedAWSSCP(aliceCtx, apispec.GetManagedAWSSCPRequestObject{
+					TeamId:    team.Id.String(),
+					AccountId: "123456789012",
+				})
+				require.NoError(t, err)
+				scp := resp.(apispec.GetManagedAWSSCP200JSONResponse)
+				assert.Equal(t, "bar", scp.Content)
+			})
+		})
+	})
+
+	t.Run("AccessReport", func(t *testing.T) {
+		resp, err := api.GetAWSAccessReport(aliceCtx, apispec.GetAWSAccessReportRequestObject{
+			TeamId:    team.Id.String(),
+			AccountId: "123456789012",
+		})
+		require.NoError(t, err)
+		report := resp.(apispec.GetAWSAccessReport200JSONResponse)
+		assert.NotEmpty(t, report.Services)
+	})
+}

--- a/backend/app/app.go
+++ b/backend/app/app.go
@@ -58,6 +58,7 @@ type App struct {
 	sqs                  map[string]AmazonSQSAPI
 	s3                   AmazonS3API
 	s3Factory            AmazonS3APIFactory
+	iamFactory           AWSIAMAPIFactory
 	urlSigner            *sign.URLSigner
 	stripe               *client.API
 }
@@ -107,7 +108,7 @@ func New(cfg Config) (*App, error) {
 	}
 
 	var awsConfig aws.Config
-	if cfg.S3 == nil || cfg.STS == nil || cfg.SQSFactory == nil || cfg.OrganizationsFactory == nil {
+	if cfg.S3 == nil || cfg.STS == nil || cfg.SQSFactory == nil {
 		awsConfig, err = config.LoadDefaultConfig(context.Background())
 		if err != nil {
 			return nil, fmt.Errorf("error loading default aws config: %w", err)
@@ -138,6 +139,11 @@ func New(cfg Config) (*App, error) {
 	organizationsFactory := cfg.OrganizationsFactory
 	if organizationsFactory == nil {
 		organizationsFactory = LiveAWSOrganizationsAPIFactory{}
+	}
+
+	iamFactory := cfg.IAMFactory
+	if iamFactory == nil {
+		iamFactory = LiveAWSIAMAPIFactory{}
 	}
 
 	sqsAPI := make(map[string]AmazonSQSAPI, len(cfg.AWSRegions))
@@ -173,6 +179,7 @@ func New(cfg Config) (*App, error) {
 		config:               cfg,
 		webAuthn:             webAuthn,
 		organizationsFactory: organizationsFactory,
+		iamFactory:           iamFactory,
 		awsRegion:            awsRegion,
 		sts:                  stsAPI,
 		sqs:                  sqsAPI,

--- a/backend/app/apptest/apptest.go
+++ b/backend/app/apptest/apptest.go
@@ -34,6 +34,8 @@ func NewTestApp(t *testing.T) *TestApp {
 		S3:                    &TestAmazonS3API{},
 		S3Factory:             &TestAmazonS3APIFactory{},
 		SQSFactory:            sqsFactory,
+		IAMFactory:            &TestAWSIAMAPIFactory{},
+		OrganizationsFactory:  &TestAWSOrganizationsAPIFactory{},
 		StripeSecretKey:       "sk_test_12345678901234567890123456789012",
 		Pricing: app.PricingConfig{
 			IndividualSubscriptionStripePriceId: DummyStripePriceIndividualSubscription.ID,

--- a/backend/app/config.go
+++ b/backend/app/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	S3                   AmazonS3API
 	S3Factory            AmazonS3APIFactory
 	OrganizationsFactory AWSOrganizationsAPIFactory
+	IAMFactory           AWSIAMAPIFactory
 	StripeAPIBackend     stripe.Backend
 }
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/iam v1.41.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.6.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.15 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -39,6 +39,8 @@ github.com/aws/aws-sdk-go-v2/service/dynamodb v1.41.1 h1:DEys4E5Q2p735j56lteNVyB
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.41.1/go.mod h1:yYaWRnVSPyAmexW5t7G3TcuYoalYfT+xQwzWsvtUQ7M=
 github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.1 h1:ZJfy2cSyoAOl7maGfRI4/J+cy00AczaYwVCow+bsc4k=
 github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.1/go.mod h1:lUqWdw5/esjPTkITXhN4C66o1ltwDq2qQ12j3SOzhVg=
+github.com/aws/aws-sdk-go-v2/service/iam v1.41.1 h1:Kq3R+K49y23CGC5UQF3Vpw5oZEQk5gF/nn+MekPD0ZY=
+github.com/aws/aws-sdk-go-v2/service/iam v1.41.1/go.mod h1:mPJkGQzeCoPs82ElNILor2JzZgYENr4UaSKUT8K27+c=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 h1:eAh2A4b5IzM/lum78bZ590jy36+d/aFLgKF/4Vd1xPE=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3/go.mod h1:0yKJC/kb8sAnmlYa6Zs3QVYqaC8ug2AbnNChv5Ox3uA=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.6.2 h1:t/gZFyrijKuSU0elA5kRngP/oU3mc0I+Dvp8HwRE4c0=

--- a/backend/model/aws_integration.go
+++ b/backend/model/aws_integration.go
@@ -16,6 +16,7 @@ type AWSIntegration struct {
 	RoleARN string
 
 	GetAccountNamesFromOrganizations bool
+	ManageSCPs                       bool
 	CloudTrailTrail                  *AWSIntegrationCloudTrailTrail
 }
 
@@ -31,6 +32,7 @@ type AWSIntegrationRecon struct {
 
 	Time           time.Time
 	ExpirationTime time.Time
+	CanManageSCPs  bool
 
 	Accounts []AWSIntegrationAccountRecon
 }
@@ -38,4 +40,18 @@ type AWSIntegrationRecon struct {
 type AWSIntegrationAccountRecon struct {
 	Id   string
 	Name string
+}
+
+type AWSSCP struct {
+	Content string
+}
+
+type AWSAccessReport struct {
+	Services []AWSAccessReportService
+}
+
+type AWSAccessReportService struct {
+	Name                   string
+	Namespace              string
+	LastAuthenticationTime time.Time
 }


### PR DESCRIPTION
## What It Does

This adds APIs to the backend that allow Cloud Snitch to manage SCPs.

## Related Issues

- https://github.com/ccbrown/cloud-snitch/issues/6