### PR TITLE
add cloudwatch alarms for dlqs

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -75,3 +75,5 @@ AWS_PROFILE=cloud-snitch-dev npx cdk deploy '*-dev'
 ## Observability
 
 The CDK deploys a CloudWatch dashboard in us-east-1 with key metrics for all regions.
+
+Alarms are created in each region and will send notifications to an SNS topic in each region. To receive notifications, you should subscribe to the SNS topic in each region.


### PR DESCRIPTION
## What It Does

Adds CloudWatch alarms for the dead letter queues.

## Related Issues

#28 