### PR TITLE
add help text to contact form and aws integration setup

### DIFF
--- a/frontend/src/app/(public-area)/contact/ContactForm.tsx
+++ b/frontend/src/app/(public-area)/contact/ContactForm.tsx
@@ -41,7 +41,10 @@ export const ContactForm = () => {
     };
 
     return success ? (
-        <SuccessMessage>Message submitted! We&apos;ll be in touch soon.</SuccessMessage>
+        <SuccessMessage>
+            Message submitted! We&apos;ll be in touch soon. If you don&apos;t see any emails from us within a few
+            business days, please be sure to check your spam folder.
+        </SuccessMessage>
     ) : (
         <>
             <p>

--- a/frontend/src/app/(user-area)/teams/[teamId]/settings/integrations/page.tsx
+++ b/frontend/src/app/(user-area)/teams/[teamId]/settings/integrations/page.tsx
@@ -17,6 +17,9 @@ interface CreateIntegrationFormProps {
     onSuccess: () => void;
 }
 
+const startsWithAwsLogsRegex = /^\/?AWSLogs($|\/)/;
+const includesAwsLogsRegex = /(^|\/)AWSLogs($|\/)/;
+
 const CreateIntegrationForm = (props: CreateIntegrationFormProps) => {
     const dispatch = useDispatch();
 
@@ -122,6 +125,20 @@ const CreateIntegrationForm = (props: CreateIntegrationFormProps) => {
                         onChange={setS3BucketName}
                     />
                     <TextField disabled={isBusy} label="S3 Key Prefix" value={s3KeyPrefix} onChange={setS3KeyPrefix} />
+                    {s3KeyPrefix &&
+                        (startsWithAwsLogsRegex.test(s3KeyPrefix) ? (
+                            <p className="text-xs text-indian-red">
+                                Cloud Snitch will automatically search for the &quot;AWSLogs&quot; directory in your S3
+                                bucket. This field is only necessary if you have a custom prefix for your CloudTrail
+                                logs. Otherwise, you should leave it empty.
+                            </p>
+                        ) : includesAwsLogsRegex.test(s3KeyPrefix) ? (
+                            <p className="text-xs text-indian-red">
+                                Cloud Snitch will automatically search for the &quot;AWSLogs&quot; directory in your S3
+                                bucket. This field should only contain the custom prefix that you specified when
+                                creating the trail, if any.
+                            </p>
+                        ) : null)}
                     <Checkbox
                         disabled={isBusy}
                         checked={getAccountNamesFromOrganizations}


### PR DESCRIPTION
## What It Does

- Adds a reminder to the contact form submission success message to check spam folders.
- Adds a warning if a user attempts to configure an integration with "AWSLogs" in the prefix.