### PR TITLE
handle deleted integrations gracefully in report generation

### DIFF
--- a/backend/app/report.go
+++ b/backend/app/report.go
@@ -263,6 +263,8 @@ func (a *App) GenerateAWSCloudTrailReport(ctx context.Context, input GenerateAWS
 	integration, err := a.store.GetAWSIntegrationById(ctx, input.AWSIntegrationId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get aws integration: %w", err)
+	} else if integration == nil {
+		return nil, nil
 	}
 
 	output, err := a.sts.AssumeRole(ctx, &sts.AssumeRoleInput{


### PR DESCRIPTION
## What It Does

Avoids a panic that would occur if a user deleted an integration in the middle of report generation.